### PR TITLE
Serialize strings as utf8; +version bump

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const MessageCache = require('./lib/message_cache.js');
 module.exports = {
   Serialize: require('./lib/base_serialize.js'),
   Deserialize: require('./lib/base_deserialize.js'),
+  getByteLength: require('./lib/encoding_utils.js').getByteLength,
   Find: MessageCache.Find,
   CMAKE_PREFIX_PATH: MessageCache.CMAKE_PREFIX_PATH,
   CMAKE_PATHS: MessageCache.CMAKE_PATHS,

--- a/lib/base_deserialize.js
+++ b/lib/base_deserialize.js
@@ -31,9 +31,8 @@
  *-----------------------------------------------------------------------------*/
 
 function StringDeserializer(buffer, bufferOffset) {
-  const len = buffer.readUInt32LE(bufferOffset[0]);
-  bufferOffset[0] += 4;
-  const str = buffer.slice(bufferOffset[0], bufferOffset[0] + len).toString();
+  const len = UInt32Deserializer(buffer, bufferOffset);
+  const str = buffer.slice(bufferOffset[0], bufferOffset[0] + len).toString('utf8');
   bufferOffset[0] += len;
   return str;
 }

--- a/lib/base_serialize.js
+++ b/lib/base_serialize.js
@@ -17,6 +17,8 @@
 
 'use strict';
 
+const getByteLength = require('./encoding_utils.js').getByteLength;
+
 /*-----------------------------------------------------------------------------
  * Primitive Serialization Functions
  *
@@ -30,9 +32,9 @@
  *-----------------------------------------------------------------------------*/
 
 function StringSerializer(value, buffer, bufferOffset) {
-  let len = value.length;
+  let len = getByteLength(value);
   bufferOffset = buffer.writeUInt32LE(len, bufferOffset);
-  return bufferOffset + buffer.write(value, bufferOffset, len, 'ascii');
+  return bufferOffset + buffer.write(value, bufferOffset, len, 'utf8');
 }
 
 function UInt8Serializer(value, buffer, bufferOffset) {

--- a/lib/encoding_utils.js
+++ b/lib/encoding_utils.js
@@ -1,0 +1,32 @@
+/*
+ *    Copyright 2016 Rethink Robotics
+ *
+ *    Copyright 2016 Chris Smith
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+'use strict';
+
+module.exports = {
+
+  /**
+   * Returns the number of bytes in a string (using utf8 encoding),
+   * in order to know the length needed to serialize it into a Buffer
+   * @param strValue
+   * @return {Number}
+   */
+  getByteLength(strValue) {
+    return Buffer.byteLength(strValue, 'utf8');
+  }
+
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ros_msg_utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provides Helper functions for ros messages",
   "main": "index.js",
   "scripts": {
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/RethinkRobotics-opensource/rosnodejs"
+    "url": "git://github.com/RethinkRobotics-opensource/ros_msg_utils"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/serialization_test.js
+++ b/test/serialization_test.js
@@ -496,8 +496,8 @@ describe('Serialization Tests', () => {
   });
 
   it('String', () => {
-    const buffer = Buffer.alloc(20);
-    const compBuf = Buffer.alloc(20);
+    const buffer = Buffer.alloc(39);
+    const compBuf = Buffer.alloc(39);
     expect(serialize.string('hi', buffer, 0)).to.equal(6);
     compBuf.writeUInt32LE(2);
     compBuf.write('hi', 4);
@@ -510,21 +510,27 @@ describe('Serialization Tests', () => {
     compBuf.writeUInt32LE(1, 15);
     compBuf.write('1', 19);
     expect(buffer.equals(compBuf)).to.be.true;
+    expect(serialize.string('こんにちは', buffer, 20)).to.equal(39);
+    compBuf.writeUInt32LE(15, 20);
+    compBuf.write('こんにちは', 24);
+    expect(buffer.equals(compBuf)).to.be.true;
   });
 
   it('String Array', () => {
-    const buffer = Buffer.alloc(28);
-    const compBuf = Buffer.alloc(28);
-    expect(serialize.Array.string(['hi', 'there'], buffer, 0, -1)).to.equal(19);
-    compBuf.writeUInt32LE(2);
+    const buffer = Buffer.alloc(47);
+    const compBuf = Buffer.alloc(47);
+    expect(serialize.Array.string(['hi', 'there', 'こんにちは'], buffer, 0, -1)).to.equal(38);
+    compBuf.writeUInt32LE(3);
     compBuf.writeUInt32LE(2, 4);
     compBuf.write('hi', 8);
     compBuf.writeUInt32LE(5, 10);
     compBuf.write('there', 14);
+    compBuf.writeUInt32LE(15, 19);
+    compBuf.write('こんにちは', 23);
     expect(buffer.equals(compBuf)).to.be.true;
-    expect(serialize.Array.string(['9'], buffer, 19, 1)).to.equal(24);
-    compBuf.writeUInt32LE(1, 19);
-    compBuf.write('9', 23);
+    expect(serialize.Array.string(['9'], buffer, 38, 1)).to.equal(43);
+    compBuf.writeUInt32LE(1, 38);
+    compBuf.write('9', 42);
     expect(buffer.equals(compBuf)).to.be.true;
   });
 });


### PR DESCRIPTION
Fixes issue with serializing unicode strings, by always serializing (and deserializing) as utf8.
This includes a util fn for getting the proper _byteLength_, not string length, when writing to
the buffer.

See note (4) under ros msg types doc: http://wiki.ros.org/msg#Field_Types

Also bumps package.json version
