### PR TITLE
Update .gitignore, .npmignore, version

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -36,5 +36,5 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 
-# ignore the npm distribution directory (from transpiling)
-dist/
+# ignore the git src directory (only publish the transpiled code)
+lib/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ros_msg_utils",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provides Helper functions for ros messages",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
- Adds `dist/` transpiled directory to `.gitignore`
- creates `.npmignore` clone of `.gitignore` except ignores `lib/` instead of `dist/`
- increments version

We should be clear to publish to `npm` after this is merged.